### PR TITLE
fix: symfony6 compatibility

### DIFF
--- a/Client/UdpClient.php
+++ b/Client/UdpClient.php
@@ -55,7 +55,7 @@ class UdpClient implements ClientInterface
     protected function getFormattedLine(string $line): string
     {
         if ($this->debugEnabled) {
-            //With debug mode on, we add a carriage return to provide more readable data
+            // With debug mode on, we add a carriage return to provide more readable data
             return $line."\n";
         }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder(M6WebStatsdPrometheusExtension::CONFIG_ROOT_KEY);
         $rootNode = $this->getRootNode($treeBuilder, M6WebStatsdPrometheusExtension::CONFIG_ROOT_KEY);

--- a/Listener/EventListener.php
+++ b/Listener/EventListener.php
@@ -40,8 +40,8 @@ class EventListener
         }
 
         foreach ($eventConfig['metrics'] as $metricConfig) {
-            //In a few cases, we need to handle events without metrics.
-            //Those events are mainly "flush events", used to send immediately the queued metrics.
+            // In a few cases, we need to handle events without metrics.
+            // Those events are mainly "flush events", used to send immediately the queued metrics.
             $this->metricHandler->addMetricToQueue(
                 (new Metric($event, $metricConfig))
             );
@@ -54,10 +54,11 @@ class EventListener
 
     public function onKernelResponse(ResponseEvent $event): void
     {
-        //We only need the master request in order to keep all the original request headers
-        //This will be used to resolve advanced configuration tags.
+        // We only need the master request in order to keep all the original request headers
+        // This will be used to resolve advanced configuration tags.
         // such as '@=request.get('queryParam')'
-        if ($event->isMasterRequest()) {
+        $isMainRequest = method_exists($event, 'isMainRequest') ? $event->isMainRequest() : $event->isMasterRequest();
+        if ($isMainRequest) {
             $this->metricHandler->setRequest($event->getRequest());
         }
     }

--- a/Listener/KernelEventsSubscriber.php
+++ b/Listener/KernelEventsSubscriber.php
@@ -54,8 +54,9 @@ class KernelEventsSubscriber implements EventSubscriberInterface
 
     public function onKernelException(ExceptionEvent $event): void
     {
+        $isMainRequest = method_exists($event, 'isMainRequest') ? $event->isMainRequest() : $event->isMasterRequest();
         if (
-            !$event->isMasterRequest()
+            !$isMainRequest
             || \in_array($event->getRequest()->attributes->get('_route'), $this->routesForWhichKernelExceptionEventWontBeDispatched, true)
         ) {
             return;

--- a/Metric/Metric.php
+++ b/Metric/Metric.php
@@ -100,7 +100,7 @@ class Metric implements MetricInterface
             return '1';
         }
         if (empty($this->paramValue)) {
-            //The param value is required for every type, except for increment which is handled above.
+            // The param value is required for every type, except for increment which is handled above.
             throw new MetricException(\sprintf('The configuration of the event metric "%s" must define the "param_value" option.', \get_class($this->event)));
         }
         if ($this->event instanceof MonitoringEventInterface) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,7 +4,7 @@ includes:
 
 parameters:
     bootstrapFiles:
-       - vendor/bin/.phpunit/phpunit-8.3-0/vendor/autoload.php
+       - vendor/bin/.phpunit/phpunit/vendor/autoload.php
     checkGenericClassInNonGenericObjectType: false
     checkMissingIterableValueType: false
     level: 'max'
@@ -16,3 +16,8 @@ parameters:
         - 'Listener'
         - 'Metric'
         - 'Tests'
+    ignoreErrors:
+        # Symfony 4 compatibility code is seen as an error on symfony 6
+        - message: '#Call to an undefined method Symfony\\Component\\HttpKernel\\Event\\[A-Za-z]+Event::isMasterRequest\(\)\.#'
+          path: Listener/*
+          count: 2


### PR DESCRIPTION
## Why?

KernelEvent::isMasterRequest has been removed in symfony6

## How?

Call KernelEvent::isMainRequest if it exists (keep compat with sf 4.4)
