### PR TITLE
Allow symfony/contract 3.* & psr/container 2.*

### DIFF
--- a/Listener/ConsoleEventsSubscriber.php
+++ b/Listener/ConsoleEventsSubscriber.php
@@ -60,9 +60,9 @@ class ConsoleEventsSubscriber implements EventSubscriberInterface
             );
         }
         $this->eventDispatcher->dispatch(
-              ConsoleTerminateMonitoringEvent::fromFacade(
-                  ConsoleMonitoringEventFacade::fromEvent($event, $this->startTime)
-              )
+            ConsoleTerminateMonitoringEvent::fromFacade(
+                ConsoleMonitoringEventFacade::fromEvent($event, $this->startTime)
+            )
         );
     }
 
@@ -70,8 +70,8 @@ class ConsoleEventsSubscriber implements EventSubscriberInterface
     {
         $this->eventDispatcher->dispatch(
             ConsoleExceptionMonitoringEvent::fromFacade(
-                  ConsoleMonitoringEventFacade::fromEvent($event, $this->startTime)
-              )
+                ConsoleMonitoringEventFacade::fromEvent($event, $this->startTime)
+            )
         );
     }
 }

--- a/Listener/EventListener.php
+++ b/Listener/EventListener.php
@@ -43,7 +43,7 @@ class EventListener
             // In a few cases, we need to handle events without metrics.
             // Those events are mainly "flush events", used to send immediately the queued metrics.
             $this->metricHandler->addMetricToQueue(
-                (new Metric($event, $metricConfig))
+                new Metric($event, $metricConfig)
             );
         }
         // We ask for the metric handler to try to send the message

--- a/Metric/Metric.php
+++ b/Metric/Metric.php
@@ -138,7 +138,7 @@ class Metric implements MetricInterface
         // Add global parameters (configured in client or group)
         foreach (array_merge($this->configurationTags, $this->tags) as $tagName => $tagValue) {
             $resolvedTag = $this->resolveTagValue(
-            // By default (~), we look for the parameter with the same name as the tag.
+                // By default (~), we look for the parameter with the same name as the tag.
                 !is_null($tagValue) ? $tagValue : self::TAG_PARAMETER_KEY.$tagName,
                 $resolvers
             );

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     },
     "require": {
         "php": "^7.2|^8.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0 || ^2.0",
         "psr/event-dispatcher": "^1.0",
-        "symfony/contracts": "^1.1 || ^2.0",
+        "symfony/contracts": "^1.1 || ^2.0 || ^3.0",
         "symfony/expression-language": "^4.4 || ^5.0 || ^6.0",
         "symfony/framework-bundle":   "^4.4 || ^5.0 || ^6.0",
         "symfony/property-access": "^4.4 || ^5.0 || ^6.0",
@@ -30,7 +30,6 @@
         "m6web/php-cs-fixer-config": "^2.0",
         "phpstan/phpstan": "0.12.*",
         "phpstan/phpstan-phpunit": "0.12.*",
-        "sensiolabs/security-checker": "6.0.*",
         "symfony/phpunit-bridge": "5.1 || ^6.0"
     },
     "suggest": {


### PR DESCRIPTION
In order to update my project in Symfony 6.2 i need `symfony/contract` 3.x & `psr/container 2.x`.

I also remove `sensiolabs/security-checker` as it is not used anymore.

Some change have been updated after running your php-cs-fixer configuration
